### PR TITLE
Agents: Add positional coverage heatmap

### DIFF
--- a/algorithms/agent.py
+++ b/algorithms/agent.py
@@ -255,10 +255,11 @@ class AgentLearner(Agent):
 
         fig = plt.figure(figsize=(4, 4))
         plt.imshow(
-            summed_histogram,
+            summed_histogram.T,
             norm=colors.LogNorm(vmin=summed_histogram.min(), vmax=summed_histogram.max()),
             cmap='RdBu_r',
         )
+        plt.gca().invert_yaxis()
         plt.colorbar()
 
         summary = visualize_matplotlib_figure_tensorboard(fig, tag)

--- a/algorithms/baselines/curious_a2c/agent_curious_a2c.py
+++ b/algorithms/baselines/curious_a2c/agent_curious_a2c.py
@@ -477,6 +477,7 @@ class AgentCuriousA2C(AgentA2C):
 
                 # wait for all the workers to complete an environment step
                 next_obs, rewards, dones, infos = multi_env.step(actions)
+                self.process_infos(infos)
                 next_img_obs, next_timer = extract_keys(next_obs, 'obs', 'timer')
 
                 # calculate curiosity bonus
@@ -554,6 +555,7 @@ class AgentCuriousA2C(AgentA2C):
             self._maybe_print(step, avg_reward, avg_length, fps, timing)
             self._maybe_aux_summaries(step, env_steps, avg_reward, avg_length)
             self._maybe_update_avg_reward(avg_reward, multi_env.stats_num_episodes())
+            self._maybe_coverage_summaries(env_steps)
 
             if step_callback is not None:
                 step_callback(locals(), globals())

--- a/algorithms/baselines/curious_ppo/agent_curious_ppo.py
+++ b/algorithms/baselines/curious_ppo/agent_curious_ppo.py
@@ -107,6 +107,7 @@ class AgentCuriousPPO(AgentPPO):
 
                     # wait for all the workers to complete an environment step
                     env_obs, rewards, dones, infos = multi_env.step(actions)
+                    self.process_infos(infos)
                     next_obs, new_goals = main_observation(env_obs), goal_observation(env_obs)
 
                     trajectory_buffer.add(obs, actions, dones)
@@ -143,6 +144,7 @@ class AgentCuriousPPO(AgentPPO):
             map_summaries(self.curiosity.episodic_maps, env_steps, self.summary_writer, 'tmax_maps', self.map_img, self.coord_limits)
             self._maybe_update_avg_reward(avg_reward, multi_env.stats_num_episodes())
             self._maybe_trajectory_summaries(trajectory_buffer, env_steps)
+            self._maybe_coverage_summaries(env_steps)
             self.curiosity.additional_summaries(env_steps, self.summary_writer, self.params.stats_episodes)
 
             trajectory_buffer.reset_trajectories()

--- a/algorithms/baselines/ppo/agent_ppo.py
+++ b/algorithms/baselines/ppo/agent_ppo.py
@@ -485,6 +485,7 @@ class AgentPPO(AgentLearner):
 
                     # wait for all the workers to complete an environment step
                     env_obs, rewards, dones, infos = multi_env.step(actions)
+                    self.process_infos(infos)
                     new_observations, new_goals = main_observation(env_obs), goal_observation(env_obs)
 
                     # add experience from all environments to the current buffer
@@ -514,6 +515,7 @@ class AgentPPO(AgentLearner):
             self._maybe_print(step, env_steps, avg_reward, avg_length, fps, timing)
             self._maybe_aux_summaries(env_steps, avg_reward, avg_length, fps)
             self._maybe_update_avg_reward(avg_reward, multi_env.stats_num_episodes())
+            self._maybe_coverage_summaries(env_steps)
 
     def learn(self):
         status = TrainStatus.SUCCESS

--- a/algorithms/multi_env.py
+++ b/algorithms/multi_env.py
@@ -66,7 +66,7 @@ class _MultiEnvWorker:
     @staticmethod
     def _get_info(env):
         info = {}
-        if hasattr(env.unwrapped, 'get_info'):
+        if hasattr(env.unwrapped, 'get_info_all'):
             info = env.unwrapped.get_info_all()  # info for the new episode
         return info
 

--- a/algorithms/multi_env.py
+++ b/algorithms/multi_env.py
@@ -67,7 +67,7 @@ class _MultiEnvWorker:
     def _get_info(env):
         info = {}
         if hasattr(env.unwrapped, 'get_info'):
-            info = env.unwrapped.get_info()  # info for the new episode
+            info = env.unwrapped.get_info_all()  # info for the new episode
         return info
 
     def start(self):

--- a/algorithms/tmax/agent_tmax.py
+++ b/algorithms/tmax/agent_tmax.py
@@ -1574,6 +1574,7 @@ class AgentTMAX(AgentLearner):
                     with timing.add_time('env_step'):
                         env_obs, rewards, dones, infos = multi_env.step(actions)
 
+                    self.process_infos(infos)
                     new_obs, new_goals = self._get_observations(env_obs)
                     trajectory_buffer.add(observations, actions, dones, modes=modes)
 
@@ -1614,6 +1615,7 @@ class AgentTMAX(AgentLearner):
             self._maybe_tmax_summaries(tmax_mgr, env_steps)
             self._maybe_update_avg_reward(avg_reward, multi_env.stats_num_episodes())
             self._maybe_trajectory_summaries(trajectory_buffer, env_steps)
+            self._maybe_coverage_summaries(env_steps)
             self.curiosity.additional_summaries(env_steps, self.summary_writer, self.params.stats_episodes)
 
             trajectory_buffer.reset_trajectories()

--- a/utils/envs/doom/play_doom.py
+++ b/utils/envs/doom/play_doom.py
@@ -4,7 +4,7 @@ from utils.envs.envs import create_env
 
 
 def main():
-    env = create_env('doom_textured_large_no_goal', mode='test', show_automap=True)
+    env = create_env('doom_textured_easy', mode='test', show_automap=True)
     return env.unwrapped.play_human_mode()
 
 

--- a/utils/graph.py
+++ b/utils/graph.py
@@ -70,6 +70,17 @@ def visualize_graph_tensorboard(nx_graph, tag, layout='pos', map_img=None, coord
     figure.clear()
     return summary
 
+def visualize_matplotlib_figure_tensorboard(figure, tag):
+    w, h = figure.canvas.get_width_height()
+
+    buffer = io.BytesIO()
+    plt.savefig(buffer, format='png', bbox_inches='tight')
+    graph_image_summary = tf.Summary.Image(encoded_image_string=buffer.getvalue(), height=h, width=w)
+    graph_summary = tf.Summary.Value(tag=tag, image=graph_image_summary)
+
+    summary = tf.Summary(value=[graph_summary])
+    figure.clear()
+    return summary
 
 def visualize_graph_html(nx_graph, output_dir=None, title_text='', layout='kamada_kawai', should_show=False):
     """


### PR DESCRIPTION
- added positional coverage heatmap for many agents
- heatmaps aggregated over the last 100 episodes
- heatmap is in log scale (since reset position will be much much higher
than others)
- heatmap logged to tensorboard (tag 'position_coverage')
- TODO: Fix rescaling values so we can directly compare heatmaps across
epochs
- TODO: overlay coverage on top of environment map